### PR TITLE
simpler script to get current totals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ roster.json
 .ipynb_checkpoints/
 temp.csv/
 .DS_Store
+*.csv

--- a/codetrack_current_totals.py
+++ b/codetrack_current_totals.py
@@ -1,0 +1,45 @@
+import json
+from datetime import datetime
+from typing import Dict, List
+from codetrack.api import get_user_by_id
+
+POINT_FIELDS = ["free_code_camp_points", "honor", "leetcode_points"]
+
+
+def codetrack_current_totals(students: List[Dict], verbose=False) -> None:
+    results = []
+    for student in students:
+        id = student["id"]  # codetrack id
+        if id > 0:  # skip students who don't have a codetrack account
+            if verbose:
+                print(f"getting current score for {student['email']}...")
+            profile = get_user_by_id(id)
+            total_score = 0
+            for field in POINT_FIELDS:
+                total_score += profile[field]
+            results.append(f"{student['email']},{total_score}\n")
+
+    return results
+
+
+def main():
+    """
+    This is a quicker way to get the current total scores for your class
+    without having to ingest data, etc.
+    You still need a roster.json file with email and codetrack id for
+    each of your learners.
+    """
+    students = None
+    with open("rosters/roster.json") as f:
+        students = json.load(f)
+
+    results = codetrack_current_totals(students, verbose=True)
+
+    with open(f"{datetime.today().strftime('%Y-%m-%d')}_totals.csv", "w+") as f2:
+        f2.write("email,score\n")
+        for result in results:
+            f2.write(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a much simpler way to get the current total points for your learners without having to go through as much of the setup and pain (no notebook etc.). Just set up your `roster.json` file, run `python codetrack_current_totals.py` and then you're good to go.