### PR TITLE
Get recently submitted problem list from leetcode

### DIFF
--- a/leetcode/api.py
+++ b/leetcode/api.py
@@ -1,0 +1,49 @@
+from typing import Dict, List
+from datetime import datetime
+import requests
+import json
+
+URL = "https://leetcode.com/graphql"
+LIMIT = 20
+
+def timestamp_to_datestr(ts: str) -> str:
+    """converts timestamp to string in YYYY-MM-DD format"""
+    d = datetime.fromtimestamp(int(ts))
+    return d.strftime('%Y-%m-%d')
+
+def fetch_submissions_for_user (username: str) -> List[Dict]:
+    """Fetch the last 20 problems with ACs (submissions that passed all tests)
+    for a particular leetcode user. 20 is a hard limit of Leetcode's API."""
+    body = {
+        "query": """
+        query recentAcSubmissions($username: String!, $limit: Int!) {
+            recentAcSubmissionList(username: $username, limit: $limit) {
+                id
+                title
+                titleSlug
+                timestamp
+            }
+        } 
+        """,
+        "variables": { "username": username, "limit": LIMIT },
+        "operationName": "recentAcSubmissions"
+    }
+    headers = {
+        "Content-Type": "application/json"
+    }
+    res = requests.post(URL, json.dumps(body), headers=headers)
+    if not res.ok:
+        res.raise_for_status()
+    
+    body = res.json()
+    submission_list = body['data']['recentAcSubmissionList']
+
+    submissions = []
+    for submission in submission_list:
+        submissions.append({ 
+            "date": timestamp_to_datestr(submission["timestamp"]),
+            "url": f"https://leetcode.com/problems/{submission['titleSlug']}"
+            })
+
+
+    return submissions

--- a/leetcode_latest_submissions.py
+++ b/leetcode_latest_submissions.py
@@ -1,0 +1,59 @@
+import json
+from typing import Dict, List
+import sys
+from datetime import datetime
+from leetcode.api import fetch_submissions_for_user
+
+
+def fetch_submissions_for_all_users(students: List[Dict], verbose=False) -> List[Dict]:
+    """
+    For each user in the roster, fetch the latest submissions
+    Returns list of lists suitable for writing to a csv
+    """
+    students = None
+    with open("rosters/roster.json") as f:
+        students = json.load(f)
+    
+    results = []
+    for student in students:
+        if student["leetcode_id"] is not None:
+            if verbose:
+                print(f"fetching submissions for {student['email']}...")
+            
+            submissions = fetch_submissions_for_user(student["leetcode_id"])
+            for submission in submissions:
+                results.append([student['email'], submission['date'], submission['url']])
+    
+    return results
+
+
+
+
+def main(verbose=False):
+
+    if len(sys.argv) != 3:
+        print("Usage: python leetcode_latest_submissions [start_date] [end_date], format 'YYYY-MM-DD'")
+        return False
+    
+    start_date = sys.argv[1]
+    end_date = sys.argv[2]
+
+    if end_date < start_date:
+        print("end_date must be >= start_date")
+        return False
+
+    students = None
+    with open("rosters/roster.json") as f:
+        students = json.load(f)
+
+    submissions = fetch_submissions_for_all_users(students, verbose=True)
+    filename = f"{end_date}_solved_problems.csv"
+    with open(filename, "w+") as f:
+        f.write('email,date,url\n')
+        for submission in submissions:
+            email, sub_date, url = submission
+            if start_date <= sub_date <= end_date:
+                f.write(f"{email},{sub_date},{url}\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a script to fetch the last 20 problems solved directly from the Leetcode API for a roster of students who have leetcode ids.

Includes a start and end date so you can get the results for a specific date range.

Leetcode's API is unofficial and has a max limit of 20 per request. I have not yet figured out how to request paginated results from Leetcode in order to increase that limit. Leetcode is using graphql and does not seem to accept the params for pagination that you typically see in other documented graphql endpoints.